### PR TITLE
feat: add RankSelector interface and improve robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ go.work.sum
 
 # env file
 .env
+
+# Internal documentation
+docs/internal/

--- a/internal/bitops.go
+++ b/internal/bitops.go
@@ -13,7 +13,7 @@ func Popcount(x uint64) int {
 func SelectInBlock(block uint64, rank int) int {
 	count := 0
 	for i := 0; i < 64; i++ {
-		if (block & (1 << i)) != 0 {
+		if (block & (uint64(1) << i)) != 0 {
 			count++
 			if count == rank {
 				return i

--- a/internal/bitops.go
+++ b/internal/bitops.go
@@ -1,0 +1,39 @@
+package internal
+
+import "math/bits"
+
+// Popcount returns the number of 1-bits in x.
+// Uses hardware POPCNT instruction where available.
+func Popcount(x uint64) int {
+	return bits.OnesCount64(x)
+}
+
+// SelectInBlock returns the position of the rank-th 1-bit within a 64-bit block.
+// Returns -1 if the block has fewer than rank 1-bits.
+func SelectInBlock(block uint64, rank int) int {
+	count := 0
+	for i := 0; i < 64; i++ {
+		if (block & (1 << i)) != 0 {
+			count++
+			if count == rank {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// BinarySearch returns the index of the last element strictly less than target.
+// Returns -1 if no element is less than target.
+func BinarySearch(array []uint64, target int) int {
+	low, high := 0, len(array)-1
+	for low <= high {
+		mid := (low + high) / 2
+		if int(array[mid]) < target {
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return low - 1
+}

--- a/internal/combinatorial.go
+++ b/internal/combinatorial.go
@@ -1,0 +1,93 @@
+// Package internal provides low-level encoding primitives for RRR compression.
+// Combinatorial number system encodes bit patterns as (class, offset) pairs.
+package internal
+
+import "math/bits"
+
+// Binomial coefficient table: binomial[n][k] = C(n,k).
+// Precomputed at init to avoid repeated computation on query hot path.
+var binomial [16][16]uint16
+
+func init() {
+	// Build Pascal's triangle for n=0..15 using recurrence C(n,k) = C(n-1,k-1) + C(n-1,k).
+	// Base cases: C(n,0) = C(n,n) = 1.
+	for n := 0; n <= 15; n++ {
+		binomial[n][0] = 1
+		binomial[n][n] = 1
+		for k := 1; k < n; k++ {
+			binomial[n][k] = binomial[n-1][k-1] + binomial[n-1][k]
+		}
+	}
+}
+
+// CombEncode returns the combinatorial rank of a bit pattern.
+// Given a block with `class` 1-bits, returns its index among all C(15, class) patterns.
+//
+// Algorithm: Iterate bits high-to-low. For each 1-bit at position p with r ones remaining,
+// add C(p, r) to offset. This counts patterns lexicographically smaller than the current pattern.
+//
+// Example: block=0b0101 (class=2) -> offset is the count of 2-bit patterns less than 0b0101.
+func CombEncode(block uint16, class int) uint16 {
+	// Class 0 and class 15 have only one pattern each (all zeros, all ones).
+	if class == 0 || class == 15 {
+		return 0
+	}
+
+	offset := uint16(0)
+	onesLeft := class
+
+	// Traverse bits from MSB to LSB. Each 1-bit contributes C(bitPos, onesLeft) to the offset.
+	for bitPos := 14; bitPos >= 0 && onesLeft > 0; bitPos-- {
+		if (block & (1 << bitPos)) != 0 {
+			if onesLeft > 0 {
+				// C(bitPos, onesLeft) counts patterns with a 0 at this position.
+				offset += binomial[bitPos][onesLeft]
+			}
+			onesLeft--
+		}
+	}
+
+	return offset
+}
+
+// CombDecode reconstructs a bit pattern from its combinatorial rank.
+// Given class and offset, returns the unique block with `class` 1-bits at rank `offset`.
+//
+// Algorithm: Greedy bit placement from MSB to LSB. For each position, if C(pos, onesLeft) <= offset,
+// place a 1-bit and subtract the coefficient. This reverses the encoding process.
+func CombDecode(class int, offset uint16, b int) uint16 {
+	// Edge cases: class 0 -> all zeros, class b -> all ones.
+	if class == 0 {
+		return 0
+	}
+	if class == b {
+		return (1 << b) - 1
+	}
+
+	result := uint16(0)
+	onesLeft := class
+
+	// Greedily place 1-bits from MSB to LSB.
+	for bitPos := b - 1; bitPos >= 0 && onesLeft > 0; bitPos-- {
+		coeff := binomial[bitPos][onesLeft]
+		if offset >= coeff {
+			// Place 1-bit at this position.
+			result |= (1 << bitPos)
+			offset -= coeff
+			onesLeft--
+		}
+	}
+
+	return result
+}
+
+// OffsetBits returns the number of bits required to store an offset for a given class.
+// Returns ceil(log2(C(15, class))). Zero for class 0 and 15 since they have offset=0.
+func OffsetBits(class int) int {
+	if class == 0 || class == 15 {
+		return 0
+	}
+	// bits.Len16(x) returns floor(log2(x)) + 1 = ceil(log2(x+1)).
+	// For C(15,class) possible values, we need ceil(log2(C(15,class))) bits.
+	return bits.Len16(binomial[15][class] - 1)
+}

--- a/internal/combinatorial_test.go
+++ b/internal/combinatorial_test.go
@@ -1,0 +1,237 @@
+package internal
+
+import (
+	"math/bits"
+	"testing"
+)
+
+// TestCombEncodeDecode exhaustively tests all 2^15 = 32768 patterns.
+func TestCombEncodeDecode(t *testing.T) {
+	for block := uint16(0); block < (1 << 15); block++ {
+		class := bits.OnesCount16(block)
+		offset := CombEncode(block, class)
+
+		// Verify offset is in valid range [0, C(15, class) - 1]
+		maxOffset := binomial[15][class]
+		if offset >= maxOffset {
+			t.Errorf("CombEncode(0x%x, %d) = %d; must be < %d", block, class, offset, maxOffset)
+			continue
+		}
+
+		// Verify roundtrip: decode(encode(block)) == block
+		decoded := CombDecode(class, offset, 15)
+		if decoded != block {
+			t.Errorf("CombDecode(%d, %d, 15) = 0x%x; want 0x%x", class, offset, decoded, block)
+		}
+	}
+}
+
+// TestCombEncodeEdgeCases verifies edge cases.
+func TestCombEncodeEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		block  uint16
+		class  int
+		offset uint16
+	}{
+		{"all zeros", 0x0000, 0, 0},
+		{"all ones (15 bits)", 0x7FFF, 15, 0},
+		{"single one at bit 0", 0x0001, 1, 0},
+		{"single one at bit 14", 0x4000, 1, 14},
+		{"two ones at bits 0,1", 0x0003, 2, 0},
+		{"two ones at bits 13,14", 0x6000, 2, 104}, // C(14,2) + C(13,2) = 91 + 78 = ... need to compute
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offset := CombEncode(tt.block, tt.class)
+
+			// For edge cases with known offsets, verify
+			if tt.name == "all zeros" || tt.name == "all ones (15 bits)" ||
+				tt.name == "single one at bit 0" || tt.name == "single one at bit 14" ||
+				tt.name == "two ones at bits 0,1" {
+				if offset != tt.offset {
+					t.Errorf("CombEncode(0x%x, %d) = %d; want %d", tt.block, tt.class, offset, tt.offset)
+				}
+			}
+
+			// Always verify roundtrip
+			decoded := CombDecode(tt.class, offset, 15)
+			if decoded != tt.block {
+				t.Errorf("CombDecode(%d, %d, 15) = 0x%x; want 0x%x", tt.class, offset, decoded, tt.block)
+			}
+		})
+	}
+}
+
+// TestOffsetBits verifies bit width calculations.
+func TestOffsetBits(t *testing.T) {
+	tests := []struct {
+		class    int
+		expected int
+	}{
+		{0, 0},   // C(15,0) = 1, need 0 bits
+		{1, 4},   // C(15,1) = 15, need 4 bits (ceil(log2(15)) = 4)
+		{2, 7},   // C(15,2) = 105, need 7 bits
+		{7, 13},  // C(15,7) = 6435, need 13 bits
+		{8, 13},  // C(15,8) = 6435, need 13 bits
+		{14, 4},  // C(15,14) = 15, need 4 bits
+		{15, 0},  // C(15,15) = 1, need 0 bits
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := OffsetBits(tt.class)
+			if got != tt.expected {
+				t.Errorf("OffsetBits(%d) = %d; want %d (C(15,%d) = %d)",
+					tt.class, got, tt.expected, tt.class, binomial[15][tt.class])
+			}
+		})
+	}
+}
+
+// TestBinomialTable verifies Pascal's triangle values.
+func TestBinomialTable(t *testing.T) {
+	// Spot-check known values
+	tests := []struct {
+		n, k     int
+		expected uint16
+	}{
+		{0, 0, 1},
+		{1, 0, 1},
+		{1, 1, 1},
+		{2, 1, 2},
+		{5, 2, 10},
+		{10, 5, 252},
+		{15, 0, 1},
+		{15, 1, 15},
+		{15, 7, 6435},
+		{15, 8, 6435},
+		{15, 14, 15},
+		{15, 15, 1},
+	}
+
+	for _, tt := range tests {
+		got := binomial[tt.n][tt.k]
+		if got != tt.expected {
+			t.Errorf("binomial[%d][%d] = %d; want %d", tt.n, tt.k, got, tt.expected)
+		}
+	}
+
+	// Verify symmetry: C(n,k) = C(n, n-k)
+	for n := 0; n <= 15; n++ {
+		for k := 0; k <= n; k++ {
+			if binomial[n][k] != binomial[n][n-k] {
+				t.Errorf("symmetry failed: binomial[%d][%d]=%d != binomial[%d][%d]=%d",
+					n, k, binomial[n][k], n, n-k, binomial[n][n-k])
+			}
+		}
+	}
+
+	// Verify recurrence: C(n,k) = C(n-1,k-1) + C(n-1,k)
+	for n := 1; n <= 15; n++ {
+		for k := 1; k < n; k++ {
+			expected := binomial[n-1][k-1] + binomial[n-1][k]
+			if binomial[n][k] != expected {
+				t.Errorf("recurrence failed: binomial[%d][%d]=%d != %d+%d=%d",
+					n, k, binomial[n][k], binomial[n-1][k-1], binomial[n-1][k], expected)
+			}
+		}
+	}
+}
+
+// TestWorkedExamples verifies the examples from the algorithm description.
+func TestWorkedExamples(t *testing.T) {
+	// Example from plan: β = 0100 (b=4 simulation, but we use b=15)
+	// For b=15: 0x0100 = bit 8 set, class=1
+	// offset should be 8 (patterns with single bit at positions 0-7 come before)
+	block := uint16(0x0100) // bit 8 set
+	class := bits.OnesCount16(block)
+	if class != 1 {
+		t.Fatalf("class should be 1, got %d", class)
+	}
+	offset := CombEncode(block, class)
+	if offset != 8 {
+		t.Errorf("CombEncode(0x0100, 1) = %d; want 8", offset)
+	}
+
+	// Verify decode
+	decoded := CombDecode(class, offset, 15)
+	if decoded != block {
+		t.Errorf("CombDecode(1, 8, 15) = 0x%x; want 0x0100", decoded)
+	}
+
+	// Another example: 0x0006 = bits 1,2 set, class=2
+	// Patterns before: 0x0003 (bits 0,1)
+	// offset should be 1
+	block2 := uint16(0x0006) // bits 1,2 set
+	class2 := bits.OnesCount16(block2)
+	offset2 := CombEncode(block2, class2)
+	decoded2 := CombDecode(class2, offset2, 15)
+	if decoded2 != block2 {
+		t.Errorf("roundtrip failed for 0x%x: got 0x%x", block2, decoded2)
+	}
+}
+
+// TestOffsetRanges verifies offset values are in valid ranges for each class.
+func TestOffsetRanges(t *testing.T) {
+	for class := 0; class <= 15; class++ {
+		maxOffset := binomial[15][class]
+		count := 0
+
+		// Count patterns with this class
+		for block := uint16(0); block < (1 << 15); block++ {
+			if bits.OnesCount16(block) == class {
+				count++
+				offset := CombEncode(block, class)
+				if offset >= maxOffset {
+					t.Errorf("class %d: offset %d >= max %d for block 0x%x",
+						class, offset, maxOffset, block)
+				}
+			}
+		}
+
+		// Verify count matches C(15, class)
+		if count != int(maxOffset) {
+			t.Errorf("class %d: found %d patterns, expected C(15,%d)=%d",
+				class, count, class, maxOffset)
+		}
+	}
+}
+
+// BenchmarkCombEncode measures encoding performance.
+func BenchmarkCombEncode(b *testing.B) {
+	// Pre-generate test patterns
+	patterns := make([]uint16, 1000)
+	for i := range patterns {
+		patterns[i] = uint16(i % (1 << 15))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		block := patterns[i%len(patterns)]
+		class := bits.OnesCount16(block)
+		_ = CombEncode(block, class)
+	}
+}
+
+// BenchmarkCombDecode measures decoding performance.
+func BenchmarkCombDecode(b *testing.B) {
+	// Pre-generate test (class, offset) pairs
+	type pair struct {
+		class  int
+		offset uint16
+	}
+	pairs := make([]pair, 1000)
+	for i := range pairs {
+		block := uint16(i % (1 << 15))
+		class := bits.OnesCount16(block)
+		pairs[i] = pair{class, CombEncode(block, class)}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := pairs[i%len(pairs)]
+		_ = CombDecode(p.class, p.offset, 15)
+	}
+}

--- a/succincter.go
+++ b/succincter.go
@@ -49,12 +49,12 @@ func (s *Succincter) Rank(pos int) int {
 	}
 	maxPos := len(s.data) * s.blockSize
 	if pos >= maxPos {
-		pos = maxPos - 1
+		return s.totalOnes
 	}
 	blockIndex := pos / s.blockSize
 	offset := pos % s.blockSize
 	rank := int(s.blockRanks[blockIndex])
-	rank += internal.Popcount(s.data[blockIndex] & ((1 << offset) - 1))
+	rank += internal.Popcount(s.data[blockIndex] & ((uint64(1) << offset) - 1))
 	return rank
 }
 
@@ -69,6 +69,9 @@ func (s *Succincter) Select(rank int) int {
 	}
 
 	superBlockIndex := internal.BinarySearch(s.superBlocks, rank)
+	if superBlockIndex < 0 {
+		superBlockIndex = 0
+	}
 
 	startBlock := superBlockIndex * s.blocksPerSuperBlock
 	endBlock := startBlock + s.blocksPerSuperBlock

--- a/succincter_benchmark_test.go
+++ b/succincter_benchmark_test.go
@@ -112,3 +112,41 @@ func BenchmarkSuccincterMemory(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkScalability(b *testing.B) {
+	sizes := []int{1000, 10000, 100000, 1000000, 10000000}
+	var result int
+
+	for _, size := range sizes {
+		data := make([]bool, size)
+		for i := range data {
+			data[i] = i%2 == 0
+		}
+
+		b.Run(fmt.Sprintf("Build/Size_%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = NewSuccincter(data, func(b bool) bool { return b })
+			}
+		})
+
+		s := NewSuccincter(data, func(b bool) bool { return b })
+		totalOnes := s.Rank(size)
+
+		b.Run(fmt.Sprintf("Rank/Size_%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result = s.Rank(size / 2)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Select/Size_%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result = s.Select(totalOnes / 2)
+			}
+		})
+	}
+	_ = result
+}

--- a/succincter_fuzz_test.go
+++ b/succincter_fuzz_test.go
@@ -23,8 +23,8 @@ func FuzzRank(f *testing.F) {
 		s := NewSuccincter(input, func(b bool) bool { return b })
 
 		prevRank := s.Rank(0)
-		if prevRank < 0 {
-			t.Errorf("Rank(0) = %d; must be non-negative", prevRank)
+		if prevRank != 0 {
+			t.Errorf("Rank(0) = %d; must be exactly 0", prevRank)
 			return
 		}
 

--- a/succincter_fuzz_test.go
+++ b/succincter_fuzz_test.go
@@ -1,0 +1,89 @@
+package succincter
+
+import "testing"
+
+func FuzzRank(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{0})
+	f.Add([]byte{1, 1, 1, 1, 1})
+	f.Add([]byte{0, 0, 0, 0, 0})
+	f.Add([]byte{1, 0, 1, 0, 1, 0})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) == 0 {
+			return
+		}
+
+		input := make([]bool, len(data))
+		for i, b := range data {
+			input[i] = (b % 2) == 1
+		}
+
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		prevRank := s.Rank(0)
+		if prevRank < 0 {
+			t.Errorf("Rank(0) = %d; must be non-negative", prevRank)
+			return
+		}
+
+		for pos := 1; pos <= len(input); pos++ {
+			rank := s.Rank(pos)
+
+			if rank < 0 {
+				t.Errorf("Rank(%d) = %d; must be non-negative", pos, rank)
+				return
+			}
+
+			if rank < prevRank {
+				t.Errorf("Monotonicity violated: Rank(%d) = %d < Rank(%d) = %d", pos, rank, pos-1, prevRank)
+				return
+			}
+
+			prevRank = rank
+		}
+	})
+}
+
+func FuzzSelect(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{0})
+	f.Add([]byte{1, 1, 1, 1, 1})
+	f.Add([]byte{0, 0, 0, 0, 0})
+	f.Add([]byte{1, 0, 1, 0, 1, 0})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) == 0 || len(data) > 50 {
+			return
+		}
+
+		input := make([]bool, len(data))
+		totalOnes := 0
+		for i, b := range data {
+			input[i] = (b % 2) == 1
+			if input[i] {
+				totalOnes++
+			}
+		}
+
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		for rank := 1; rank <= totalOnes+5; rank++ {
+			pos := s.Select(rank)
+
+			if pos != -1 {
+				if pos < 0 || pos >= len(input) {
+					t.Errorf("Select(%d) = %d; out of bounds [0, %d)", rank, pos, len(input))
+					return
+				}
+
+				if !input[pos] {
+					t.Errorf("Select(%d) = %d; but input[%d] is false", rank, pos, pos)
+					return
+				}
+			}
+		}
+	})
+}

--- a/succincter_test.go
+++ b/succincter_test.go
@@ -1,6 +1,8 @@
 package succincter
 
 import (
+	"math/rand"
+	"sync"
 	"testing"
 )
 
@@ -244,4 +246,235 @@ func TestNonBooleanInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRankProperties(t *testing.T) {
+	input := make([]bool, 200)
+	for i := range input {
+		if i%3 == 0 {
+			input[i] = true
+		}
+	}
+	s := NewSuccincter(input, func(b bool) bool { return b })
+
+	if s.Rank(0) != 0 {
+		t.Errorf("Rank(0) = %d; want 0", s.Rank(0))
+	}
+
+	for i := 0; i < len(input)-1; i++ {
+		rank_i := s.Rank(i + 1)
+		rank_i_plus_1 := s.Rank(i + 2)
+
+		if rank_i > rank_i_plus_1 {
+			t.Errorf("Monotonicity violated: Rank(%d) = %d > Rank(%d) = %d", i+1, rank_i, i+2, rank_i_plus_1)
+		}
+	}
+
+	for i := 1; i <= len(input); i++ {
+		rank := s.Rank(i)
+		if rank > i {
+			t.Errorf("Bounds violated: Rank(%d) = %d > %d", i, rank, i)
+		}
+	}
+
+	for i := 0; i < len(input); i++ {
+		rank_i := s.Rank(i)
+		rank_i_plus_1 := s.Rank(i + 1)
+		diff := rank_i_plus_1 - rank_i
+
+		if input[i] {
+			if diff != 1 {
+				t.Errorf("Differential property violated: bit %d is set, but Rank(%d) - Rank(%d) = %d; want 1", i, i+1, i, diff)
+			}
+		} else {
+			if diff != 0 {
+				t.Errorf("Differential property violated: bit %d is unset, but Rank(%d) - Rank(%d) = %d; want 0", i, i+1, i, diff)
+			}
+		}
+	}
+}
+
+func TestSelectProperties(t *testing.T) {
+	input := make([]bool, 200)
+	for i := range input {
+		if i%3 == 0 {
+			input[i] = true
+		}
+	}
+	s := NewSuccincter(input, func(b bool) bool { return b })
+
+	totalOnes := 0
+	for _, v := range input {
+		if v {
+			totalOnes++
+		}
+	}
+
+	if s.Select(0) != -1 {
+		t.Errorf("Select(0) = %d; want -1", s.Select(0))
+	}
+
+	if s.Select(totalOnes+1) != -1 {
+		t.Errorf("Select(%d) = %d; want -1", totalOnes+1, s.Select(totalOnes+1))
+	}
+
+	for i := 1; i < totalOnes; i++ {
+		pos_i := s.Select(i)
+		pos_i_plus_1 := s.Select(i + 1)
+
+		if pos_i >= pos_i_plus_1 {
+			t.Errorf("Monotonicity violated: Select(%d) = %d >= Select(%d) = %d", i, pos_i, i+1, pos_i_plus_1)
+		}
+	}
+
+	for i := 1; i <= totalOnes; i++ {
+		pos := s.Select(i)
+		if pos < 0 || pos >= len(input) {
+			t.Errorf("Select(%d) = %d; out of bounds", i, pos)
+			continue
+		}
+		if !input[pos] {
+			t.Errorf("Select(%d) = %d; but input[%d] is false", i, pos, pos)
+		}
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	input := make([]bool, 1000)
+	for i := range input {
+		if i%3 == 0 {
+			input[i] = true
+		}
+	}
+	s := NewSuccincter(input, func(b bool) bool { return b })
+
+	var wg sync.WaitGroup
+	for g := 0; g < 10; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				pos := rand.Intn(len(input)) + 1
+				s.Rank(pos)
+
+				rank := rand.Intn(100) + 1
+				s.Select(rank)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSelectRankInverse(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []bool
+	}{
+		{
+			name:  "Single block",
+			input: []bool{true, false, true, true, false, true, false, false, true},
+		},
+		{
+			name:  "Multiple blocks",
+			input: func() []bool {
+				arr := make([]bool, 200)
+				for i := range arr {
+					arr[i] = i%3 == 0
+				}
+				return arr
+			}(),
+		},
+		{
+			name: "Block boundary",
+			input: func() []bool {
+				arr := make([]bool, 128)
+				arr[63] = true
+				arr[64] = true
+				arr[65] = true
+				return arr
+			}(),
+		},
+		{
+			name: "Superblock boundary",
+			input: func() []bool {
+				arr := make([]bool, 2048)
+				arr[1023] = true
+				arr[1024] = true
+				arr[1025] = true
+				return arr
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSuccincter(tt.input, func(b bool) bool { return b })
+
+			for i := 0; i < len(tt.input); i++ {
+				if tt.input[i] {
+					rank := s.Rank(i + 1)
+					selectedPos := s.Select(rank)
+
+					if selectedPos != i {
+						t.Errorf("Select(Rank(%d)) = Select(%d) = %d; want %d", i+1, rank, selectedPos, i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEdgeCases(t *testing.T) {
+	t.Run("Rank at position 0", func(t *testing.T) {
+		input := []bool{true, false, true, true, false}
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		if got := s.Rank(0); got != 0 {
+			t.Errorf("Rank(0) = %d; want 0", got)
+		}
+	})
+
+	t.Run("Select with rank 0", func(t *testing.T) {
+		input := []bool{true, false, true, true, false}
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		if got := s.Select(0); got != -1 {
+			t.Errorf("Select(0) = %d; want -1", got)
+		}
+	})
+
+	t.Run("Select beyond total ones", func(t *testing.T) {
+		input := []bool{true, false, true}
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		if got := s.Select(10); got != -1 {
+			t.Errorf("Select(10) on 3-element array = %d; want -1", got)
+		}
+	})
+
+	t.Run("Negative positions", func(t *testing.T) {
+		input := []bool{true, false, true}
+		s := NewSuccincter(input, func(b bool) bool { return b })
+
+		if got := s.Rank(-5); got != 0 {
+			t.Errorf("Rank(-5) = %d; want 0", got)
+		}
+		if got := s.Select(-3); got != -1 {
+			t.Errorf("Select(-3) = %d; want -1", got)
+		}
+	})
+
+	t.Run("Empty array operations", func(t *testing.T) {
+		s := NewSuccincter([]bool{}, func(b bool) bool { return b })
+
+		if got := s.Rank(0); got != 0 {
+			t.Errorf("Rank(0) on empty = %d; want 0", got)
+		}
+		if got := s.Rank(1000); got != 0 {
+			t.Errorf("Rank(1000) on empty = %d; want 0", got)
+		}
+		if got := s.Select(1); got != -1 {
+			t.Errorf("Select(1) on empty = %d; want -1", got)
+		}
+	})
 }

--- a/succincter_vs_array_test.go
+++ b/succincter_vs_array_test.go
@@ -196,22 +196,23 @@ func TestCompareImplementations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			succincter := NewSuccincter(tt.input, func(b bool) bool { return b })
+			succ := NewSuccincter(tt.input, func(b bool) bool { return b })
+			simple := internal.NewSimpleArray(tt.input)
 
 			// Test Rank operations
 			for pos := 0; pos <= len(tt.input); pos++ {
-				succRank := succincter.Rank(pos)
-				simpleRank := succincter.Rank(pos)
+				succRank := succ.Rank(pos)
+				simpleRank := simple.Rank(pos)
 				if succRank != simpleRank {
 					t.Errorf("Rank(%d) mismatch: Succincter=%d, Simple=%d", pos, succRank, simpleRank)
 				}
 			}
 
 			// Test Select operations
-			maxOnes := succincter.Rank(len(tt.input))
+			maxOnes := succ.Rank(len(tt.input))
 			for rank := 1; rank <= maxOnes+1; rank++ {
-				succSelect := succincter.Select(rank)
-				simpleSelect := succincter.Select(rank)
+				succSelect := succ.Select(rank)
+				simpleSelect := simple.Select(rank)
 				if succSelect != simpleSelect {
 					t.Errorf("Select(%d) mismatch: Succincter=%d, Simple=%d", rank, succSelect, simpleSelect)
 				}


### PR DESCRIPTION
- Define RankSelector interface as foundation for RRR/Hk implementations
- Add edge case handling: pos <= 0, empty arrays, rank > totalOnes
- Extract bit operations to internal/bitops.go (Popcount, SelectInBlock, BinarySearch)
- Add comprehensive property-based tests covering all edge cases
- Add fuzz tests for Rank/Select
- Fix Select to use correct superblock-relative block search