### PR TITLE
docs: correct space and speed claims with measured benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Go library implementing succinct data structures for efficient rank and select
 
 ## Overview
 
-Succincter provides O(1) rank queries and O(log n) select queries on compressed boolean arrays with only ~1.5 bits per element overhead. It uses a generic constructor that accepts any slice type and a predicate function.
+Succincter provides O(1) rank queries and O(log n) select queries on compressed boolean arrays, costing ~2.06 bits per element — bit vector and rank index combined, under a third of what a Go `[]bool` spends on the booleans alone. It uses a generic constructor that accepts any slice type and a predicate function.
 
 ## Installation
 
@@ -89,22 +89,38 @@ func FullVersion() string  // Returns version with prerelease tag if set
 
 ## Performance
 
-| Operation    | Time       | Space Overhead       |
-|-------------|------------|---------------------|
-| Construction | O(n)       | ~1.5 bits/element   |
+| Operation    | Time       | Space               |
+|--------------|------------|---------------------|
+| Construction | O(n)       | ~2.06 bits/element  |
 | Rank         | O(1)       | —                   |
 | Select       | O(log n)   | —                   |
 
+Space breaks down as 1 bit/element for the packed bit vector, 1 bit/element for
+the per-word rank index, and 1/16 bit/element for the superblock index. Measured
+heap is ~2.18 bits/element, since both index arrays are grown with `append` and
+no preallocation.
+
 ### Benchmarks
 
-Measured on Intel Core Ultra 9 (see `go test -bench=.` for your system):
+Measured on a 13th Gen Intel Core i9-13980HX, Go 1.25.5, querying **scattered**
+positions (see `go test -bench=.` for your system):
 
-| Dataset Size | Naive Rank | Succincter Rank | Speedup |
-|--------------|------------|-----------------|---------|
-| 10K          | ~3µs       | ~13ns           | ~220x   |
-| 100K         | ~30µs      | ~13ns           | ~2,300x |
+| Dataset Size | Naive Rank | Succincter Rank | Speedup     |
+|--------------|------------|-----------------|-------------|
+| 10K          | 3.60µs     | 2.7ns           | ~1,300x     |
+| 100K         | 161µs      | 14.0ns          | ~11,500x    |
+| 1M           | 1.88ms     | 16.6ns          | ~113,000x   |
+| 10M          | 20.6ms     | 18.0ns          | ~1,145,000x |
 
-Speedup scales linearly with data size (naive is O(n), Succincter is O(1)).
+Naive is O(n) with a constant that worsens as the scan falls out of cache;
+Succincter's rank is O(1).
+
+Note that repeatedly ranking the *same* position measures ~2.6ns, because its
+cache lines never leave L1. That best case is not what a real workload sees — the
+table above uses scattered positions. Select is more cache-sensitive still:
+~17-30ns for a repeated rank against ~228-533ns for scattered ranks.
+
+Full measurements and methodology: [docs/bench/results.md](docs/bench/results.md).
 
 Run benchmarks:
 
@@ -129,8 +145,8 @@ go run ./examples/loganalysis
 
 ## Documentation
 
-- [Finding Errors in Log Streams](docs/posts/finding-errors-in-log-streams.md) - Real-world usage tutorial
-- [Combinatorial Encoding](docs/posts/combinatorial-encoding-for-compression.md) - Foundation for RRR compression
+- [Finding Errors in Log Streams](https://slow-is-smooth.io/blog/finding-errors-in-log-streams/) - Real-world usage tutorial
+- [Benchmark results](docs/bench/results.md) - Raw measurements and methodology
 
 ## Thread Safety
 

--- a/docs/bench/results.md
+++ b/docs/bench/results.md
@@ -1,0 +1,197 @@
+# Benchmark results
+
+Raw measurements backing the numbers quoted in
+[Finding Errors in Log Streams](https://slow-is-smooth.io/blog/finding-errors-in-log-streams/).
+
+**Environment**
+
+| | |
+|---|---|
+| CPU | 13th Gen Intel(R) Core(TM) i9-13980HX (32 logical cores) |
+| OS / arch | windows / amd64 |
+| Go | go1.25.5 |
+| Date | 2026-09-05 |
+
+**Methodology.** Benchmarks ran from a separate module that imports the library
+through a `replace` directive, so the repository's `go.mod` was untouched. Every
+timed loop accumulates its result into a package-level `var sink int`. This
+matters: without it the compiler may inline `Rank` and discard the call, and the
+measured time collapses toward zero.
+
+Log entries are generated with a fixed seed (`rand.NewSource(42)`) at a 5% error
+rate, so runs are reproducible. The `LogEntry` struct is deliberately lean (one
+`string` field). A fatter struct makes the naive scan slower through worse cache
+behaviour, which would inflate the speedup — this is the conservative choice.
+
+---
+
+## Two Rank numbers, and why they differ
+
+The repository quoted both "~2ns" (post, `examples/README.md`) and "~13ns"
+(`README.md`, `plans/roadmap.md`). **Both are correct.** They measure different
+things, and the difference is entirely cache behaviour:
+
+| Access pattern | 1M entries | What it represents |
+|---|---|---|
+| Same position, every iteration | **2.56 ns** | Best case. The three cache lines involved never leave L1. |
+| Scattered positions (1024-entry ring) | **16.56 ns** | Realistic. A dashboard queries different positions. |
+
+The scattered figure includes ~3 ns of ring-buffer indexing overhead, measured
+separately below. The post quotes the scattered numbers.
+
+---
+
+## Rank — same position (hot cache)
+
+```
+BenchmarkRank/Naive/10K-32                331960          3601 ns/op       0 B/op   0 allocs/op
+BenchmarkRank/Succincter/10K-32        473400606             2.606 ns/op   0 B/op   0 allocs/op
+BenchmarkRank/Naive/100K-32                 8030        161311 ns/op       0 B/op   0 allocs/op
+BenchmarkRank/Succincter/100K-32       482023147             2.546 ns/op   0 B/op   0 allocs/op
+BenchmarkRank/Naive/1M-32                    597       1878963 ns/op       0 B/op   0 allocs/op
+BenchmarkRank/Succincter/1M-32         457384180             2.562 ns/op   0 B/op   0 allocs/op
+BenchmarkRank/Naive/10M-32                    51      20600498 ns/op       0 B/op   0 allocs/op
+BenchmarkRank/Succincter/10M-32        454813346             2.608 ns/op   0 B/op   0 allocs/op
+```
+
+## Rank — scattered positions (realistic)
+
+```
+BenchmarkRankScattered/RingOverhead/10K-32     798635397    1.434 ns/op
+BenchmarkRankScattered/Succincter/10K-32       462607618    2.715 ns/op
+BenchmarkRankScattered/RingOverhead/100K-32    849758455    2.733 ns/op
+BenchmarkRankScattered/Succincter/100K-32      100000000   13.97  ns/op
+BenchmarkRankScattered/RingOverhead/1M-32      437276350    3.178 ns/op
+BenchmarkRankScattered/Succincter/1M-32         78592666   16.56  ns/op
+BenchmarkRankScattered/RingOverhead/10M-32     376306488    3.095 ns/op
+BenchmarkRankScattered/Succincter/10M-32        70134423   17.97  ns/op
+```
+
+Note the naive scan's *per-entry* cost also grows with n, because the scan falls
+out of successive cache levels: 0.72 ns/entry at 10K, 3.2 at 100K, 3.8 at 1M,
+4.1 at 10M. Naive is O(n), but with a worsening constant.
+
+## Select
+
+```
+BenchmarkSelect/Naive/10K-32              299092      4445 ns/op
+BenchmarkSelect/Succincter/10K-32       44289267        26.46 ns/op
+BenchmarkSelect/Naive/100K-32               7219    161533 ns/op
+BenchmarkSelect/Succincter/100K-32      50476582        23.99 ns/op
+BenchmarkSelect/Naive/1M-32                  615   1966941 ns/op
+BenchmarkSelect/Succincter/1M-32        80082751        16.67 ns/op
+BenchmarkSelect/Naive/10M-32                  49  22322494 ns/op
+BenchmarkSelect/Succincter/10M-32       50638680        30.02 ns/op
+
+BenchmarkSelectScattered/Succincter/10K-32     6258124   228.1 ns/op
+BenchmarkSelectScattered/Succincter/100K-32    3781868   314.8 ns/op
+BenchmarkSelectScattered/Succincter/1M-32      2775885   423.4 ns/op
+BenchmarkSelectScattered/Succincter/10M-32     2140524   533.0 ns/op
+```
+
+Select is far more cache-sensitive than Rank — 17–30 ns for a repeated rank
+versus 228–533 ns for scattered ranks. Two reasons: `BinarySearch` over the
+superblock array walks ~13 cold cache lines at 10M, and `SelectInBlock`
+([internal/bitops.go:13](../../internal/bitops.go#L13)) is a plain linear scan of
+up to 64 bit positions rather than a constant-time bit trick.
+
+## Build
+
+```
+BenchmarkBuild/10K-32      30058     38338 ns/op      5728 B/op   16 allocs/op
+BenchmarkBuild/100K-32      2662    488960 ns/op     55264 B/op   23 allocs/op
+BenchmarkBuild/1M-32         241   5114798 ns/op    645088 B/op   34 allocs/op
+BenchmarkBuild/10M-32         21  52691510 ns/op   8227424 B/op   51 allocs/op
+```
+
+---
+
+## Memory
+
+Three different numbers, often confused. All for a 5% error rate:
+
+| n | Analytical | Retained heap | `B/op` churn | `[]bool` |
+|---|---|---|---|---|
+| 100K | 25,792 B | 29,016 B | 55,264 B | 100,000 B |
+| 1M | 257,816 B | 272,544 B | 645,088 B | 1,000,000 B |
+| 10M | 2,578,128 B | 2,752,656 B | 8,227,424 B | 10,000,000 B |
+
+| | bits/element at 1M |
+|---|---|
+| Analytical (exact array lengths) | **2.0625** |
+| Retained heap (measured, includes `append` slack) | **2.18** |
+| `[]bool` baseline | 8.00 |
+
+**Analytical** follows directly from the constructor
+([succincter.go:26-31](../../succincter.go#L26-L31)), where `blockSize=64` and
+`superBlockSize=1024`. With `B = ceil(n/64)`:
+
+```
+data        = B * 8 bytes                 = 1.0    bits/element
+blockRanks  = B * 8 bytes                 = 1.0    bits/element
+superBlocks = ceil(B/16) * 8 bytes        = 0.0625 bits/element
+                                          ---------------------
+                                            2.0625 bits/element
+```
+
+**Retained** is `runtime.HeapAlloc` delta across construction with a forced GC
+either side. It exceeds analytical by ~6% because
+[succincter.go:92-93](../../succincter.go#L92-L93) grows `blockRanks` and
+`superBlocks` with `append` and no preallocation, leaving capacity slack.
+(The 10K row is unreliable at this size — GC noise exceeded the signal — so it is
+omitted.)
+
+**Churn** is `-benchmem` `B/op`, which counts *every* intermediate allocation
+during append growth, not the resting footprint. It is a construction cost, not
+a memory overhead. Preallocating with `make([]uint64, 0, B)` would remove most
+of it.
+
+The claim of "~1.5 bits/element" that appeared throughout the repository
+described the pre-`uint64` layout; see the `[]uint32` → `[]uint64` migration in
+[CHANGELOG.md](../../CHANGELOG.md). Under that layout the total was
+`1 + 0.5 + 0.03125 = 1.53` bits/element.
+
+---
+
+## Example transcript
+
+`go run ./examples/loganalysis`, after the timing fix described above:
+
+```
+=== Succincter Log Analysis Example ===
+Generating 1000000 log entries (5% errors)...
+Building Succincter index...
+Index built in 8.0052ms
+
+
+--- Query Examples ---
+1. Errors before position 500000: 25150 (query time: 0s)
+2. Position of error #1000: 19322 (query time: 0s)
+   Verification: logs[19322].Level = "ERROR"
+3. Errors in range [100000, 200000): 5072 (query time: 0s)
+
+4. First 5 errors:
+   Error 1 at position 10: Log message 10
+   Error 2 at position 46: Log message 46
+   Error 3 at position 55: Log message 55
+   Error 4 at position 58: Log message 58
+   Error 5 at position 76: Log message 76
+
+--- Performance Comparison ---
+Rank(500000):
+  Naive:      2.185981ms avg (100 iterations)
+  Succincter: 2ns avg (1000000 iterations)
+  Speedup:    1092990x
+  (checksum 25152515000, printed so the timed loops cannot be optimized away)
+```
+
+Two things to read carefully here:
+
+- `query time: 0s` is a **clock-resolution artifact**, not a claim of zero time.
+  Windows' monotonic clock cannot resolve a single ~3 ns operation.
+- `Succincter: 2ns` is the *hot-cache, same-position* figure, and
+  `time.Duration` truncates 2.6 ns to `2ns`. The `1092990x` speedup follows from
+  it and is therefore a best case, not a typical one.
+
+The error counts vary between runs: the example seeds `math/rand` implicitly, so
+the generated data differs each time.

--- a/examples/README.md
+++ b/examples/README.md
@@ -98,7 +98,7 @@ Demonstrates:
 - Indexing structured data (log entries) by a field predicate
 - Counting errors before a timestamp/position
 - Finding the Nth error for pagination
-- Performance comparison vs naive O(n) scanning (~50,000x speedup)
+- Performance comparison vs naive O(n) scanning (~113,000x at 1M entries)
 
 Use cases:
 - Log monitoring dashboards
@@ -245,13 +245,18 @@ Use cases:
 
 All examples demonstrate O(1) rank and O(log n) select queries, compared to O(n) for naive filtering approaches:
 
-| Dataset Size | Naive Filter | Succincter Rank | Speedup |
-|--------------|--------------|-----------------|---------|
-| 100K         | ~10µs        | ~2ns            | 5,000x  |
-| 1M           | ~100µs       | ~2ns            | 50,000x |
-| 10M          | ~1ms         | ~2ns            | 500,000x|
+| Dataset Size | Naive Filter | Succincter Rank | Speedup     |
+|--------------|--------------|-----------------|-------------|
+| 100K         | 161µs        | 14.0ns          | ~11,500x    |
+| 1M           | 1.88ms       | 16.6ns          | ~113,000x   |
+| 10M          | 20.6ms       | 18.0ns          | ~1,145,000x |
 
-Construction is O(n) and happens once. Queries are nearly instant regardless of data size.
+Measured on a 13th Gen Intel Core i9-13980HX, Go 1.25.5, querying scattered
+positions. Repeatedly ranking the *same* position measures ~2.6ns instead, because
+its cache lines stay in L1 — a best case rather than a typical one. Full
+measurements: [docs/bench/results.md](../docs/bench/results.md).
+
+Construction is O(n) and happens once: 489µs at 100K, 5.1ms at 1M, 52.7ms at 10M.
 
 ## Creating Your Own
 
@@ -281,5 +286,5 @@ countInRange := activeIndex.Rank(end) - activeIndex.Rank(start)  // O(1)
 
 ## Further Reading
 
-- [Finding Errors in Log Streams](../docs/posts/finding-errors-in-log-streams.md) - Detailed tutorial
-- [Combinatorial Encoding](../docs/posts/combinatorial-encoding-for-compression.md) - Compression internals
+- [Finding Errors in Log Streams](https://slow-is-smooth.io/blog/finding-errors-in-log-streams/) - Detailed tutorial
+- [Benchmark results](../docs/bench/results.md) - Raw measurements and methodology

--- a/examples/loganalysis/main.go
+++ b/examples/loganalysis/main.go
@@ -17,6 +17,11 @@ type LogEntry struct {
 	Message   string
 }
 
+// sink accumulates results from the timed loops below. Without it the compiler
+// is free to inline Rank and discard the call entirely, which makes the
+// measured time collapse toward zero and the reported speedup meaningless.
+var sink int
+
 func main() {
 	fmt.Println("=== Succincter Log Analysis Example ===")
 
@@ -99,7 +104,7 @@ func comparePerformance(logs []LogEntry, index *succincter.Succincter) {
 	naiveIterations := 100
 	start := time.Now()
 	for i := 0; i < naiveIterations; i++ {
-		naiveCountBefore(logs, testPos)
+		sink += naiveCountBefore(logs, testPos)
 	}
 	naiveTotal := time.Since(start)
 	naiveAvg := naiveTotal / time.Duration(naiveIterations)
@@ -108,7 +113,7 @@ func comparePerformance(logs []LogEntry, index *succincter.Succincter) {
 	succincterIterations := 1_000_000
 	start = time.Now()
 	for i := 0; i < succincterIterations; i++ {
-		index.Rank(testPos)
+		sink += index.Rank(testPos)
 	}
 	succincterTotal := time.Since(start)
 	succincterAvg := succincterTotal / time.Duration(succincterIterations)
@@ -117,6 +122,7 @@ func comparePerformance(logs []LogEntry, index *succincter.Succincter) {
 	fmt.Printf("  Naive:      %v avg (%d iterations)\n", naiveAvg, naiveIterations)
 	fmt.Printf("  Succincter: %v avg (%d iterations)\n", succincterAvg, succincterIterations)
 	fmt.Printf("  Speedup:    %.0fx\n", float64(naiveAvg)/float64(succincterAvg))
+	fmt.Printf("  (checksum %d, printed so the timed loops cannot be optimized away)\n", sink)
 }
 
 func naiveCountBefore(logs []LogEntry, pos int) int {

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -24,9 +24,12 @@
 - [x] **M8: Alternative Evaluation** — GO decision documented in Decision Log section of this roadmap
 
 ### Performance
-- [x] **M9: Performance Validation** — Benchmarks confirm O(1) rank (~13ns), O(log n) select (~100-120ns)
+- [x] **M9: Performance Validation** — Benchmarks confirm O(1) rank (~14-18ns scattered,
+      ~2.6ns same-position hot cache), O(log n) select (~228-533ns scattered)
   - [x] Scalability benchmarks across 1K–10M elements
-  - [x] Memory overhead validated at ~1.5 bits/element
+  - [x] Memory overhead validated at 2.06 bits/element analytical, ~2.18 measured
+        (see `docs/bench/results.md`). The earlier ~1.5 figure described the
+        pre-`uint64` index layout.
 
 ### Refactoring
 - [x] **R1: Extract bit operations** — `internal/bitops.go` (Popcount, SelectInBlock, BinarySearch)
@@ -105,7 +108,7 @@ Query Phase:
 
 ### Design Tradeoffs
 
-- **Memory vs Speed**: ~1.5 bits/element overhead for O(1) rank (vs O(n) naive)
+- **Memory vs Speed**: ~2.06 bits/element for O(1) rank (vs O(n) naive)
 - **Construction vs Query**: One-time O(n) construction for amortized O(1) queries
 - **Generic API vs Performance**: Generic predicate adds negligible overhead vs flexibility gained
 - **uint64 vs uint32 Ranks**: uint64 doubles rank memory but prevents silent overflow at >537M elements

--- a/succincter.go
+++ b/succincter.go
@@ -9,7 +9,8 @@ type RankSelector interface {
 }
 
 // Succincter is a succinct data structure for O(1) rank and O(log n) select queries
-// on boolean arrays, with ~1.5 bits per element overhead.
+// on boolean arrays, costing ~2.06 bits per element: 1 bit for the packed bit
+// vector, 1 bit for the per-word rank index, and 1/16 bit for the superblock index.
 type Succincter struct {
 	data               []uint64
 	blockRanks         []uint64


### PR DESCRIPTION
## Why

Three claims in the repository did not survive measurement:

- **`~1.5 bits/element`** described the pre-`uint64` index layout. The current layout is `1 + 1 + 1/16 = 2.0625` bits/element analytically, ~2.18 measured (both index arrays grow via `append` with no preallocation).
- **The quoted rank speedups** came from repeatedly ranking the *same* position — a hot-L1 best case (~2.6ns) rather than what a dashboard querying scattered positions sees (~14-18ns).
- **The log analysis example's timed loops discarded their results**, leaving the compiler free to inline `Rank` and drop the call, which collapses the measured time toward zero.

Two README links also pointed at `docs/posts/*.md` files that were never present in the repository.

## What changed

- Quote scattered-position numbers in `README.md`, `examples/README.md`, `plans/roadmap.md`, and the `Succincter` doc comment; note the hot-cache figure explicitly rather than dropping it.
- Add `docs/bench/results.md` with the raw `go test -bench` output, the environment, the methodology, and the memory breakdown (analytical vs. retained heap vs. `B/op` churn — three numbers that were being conflated).
- Accumulate into a package-level `sink` in `examples/loganalysis/main.go` and print the checksum, so the timing means something.
- Repoint the two broken doc links at the published post.

Benchmarks were run from a separate module using a `replace` directive, so `go.mod` is untouched.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. No behavioural change to the library — the only non-doc edit is the `sink` accumulation in the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
