### PR TITLE
docs: restore the combinatorial encoding walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ go run ./examples/loganalysis
 
 - [Finding Errors in Log Streams](https://slow-is-smooth.io/blog/finding-errors-in-log-streams/) - Real-world usage tutorial
 - [Benchmark results](docs/bench/results.md) - Raw measurements and methodology
+- [Combinatorial encoding: a tiny worked example](docs/combinatorial-walkthrough.md) - How `CombEncode`/`CombDecode` map a block to `(class, offset)` and back
 
 **RRR encoding (combinatorial number system):** each 15-bit block is stored as a `(class, offset)` pair, where `class` is the popcount and `offset` is the block's index among `C(15, class)` patterns. The offset shrinks from 15 bits at class = 7/8 down to 9 bits at class = 3 and 4 bits at class = 1 — that compression vs. raw bits is where the `nH₀(B)` space bound comes from.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ go run ./examples/loganalysis
 - [Benchmark results](docs/bench/results.md) - Raw measurements and methodology
 - [Combinatorial encoding: a tiny worked example](docs/combinatorial-walkthrough.md) - How `CombEncode`/`CombDecode` map a block to `(class, offset)` and back
 
-**RRR encoding (combinatorial number system):** each 15-bit block is stored as a `(class, offset)` pair, where `class` is the popcount and `offset` is the block's index among `C(15, class)` patterns. The offset shrinks from 15 bits at class = 7/8 down to 9 bits at class = 3 and 4 bits at class = 1 — that compression vs. raw bits is where the `nH₀(B)` space bound comes from.
+**RRR encoding (combinatorial number system):** each 15-bit block is stored as a `(class, offset)` pair, where `class` is the popcount and `offset` is the block's index among `C(15, class)` patterns. The offset shrinks from 13 bits at class = 7/8 down to 9 bits at class = 3 and 4 bits at class = 1 — that compression vs. raw bits is where the `nH₀(B)` space bound comes from. Note the class itself costs 4 bits, so only skewed blocks are a net win; see the [walkthrough's cost table](docs/combinatorial-walkthrough.md#what-it-buys-and-when-it-doesnt).
 
 ## Thread Safety
 

--- a/docs/combinatorial-walkthrough.md
+++ b/docs/combinatorial-walkthrough.md
@@ -1,0 +1,68 @@
+# Combinatorial Encoding: A Tiny Worked Example
+
+A minimal walkthrough of how `CombEncode` and `CombDecode` map a bit pattern to its index among all patterns with the same popcount, and back. This page uses a 4-bit example so the whole derivation fits on one screen. For the canonical 15-bit case as it appears in production code, see [combinatorial-encoding-for-compression.md](posts/combinatorial-encoding-for-compression.md).
+
+## The Problem
+
+Given a `b`-bit block β with `c` 1-bits (its **class**), there are exactly `C(b, c)` possible patterns. Assigning each pattern a unique index in `[0, C(b, c) - 1]` (its **offset**) lets us replace the `b` raw bits with `(class, offset)` — and the offset takes only `⌈log₂ C(b, c)⌉` bits, which is smaller than `b` whenever the pattern is sparse or dense.
+
+This file walks the algorithm on β = `0100` (b = 4, class = 1). The answer is o = 2.
+
+## Encode: 0100 → 2
+
+`CombEncode` scans bit positions from MSB (position 3) down to LSB (position 0). At each 1-bit it adds `C(p, onesLeft)` to the running offset and decrements `onesLeft`. That coefficient counts the patterns lexicographically smaller than β that have a 0 at this position.
+
+| bitPos `p` | bit | onesLeft `r` | C(p, r) added | offset after |
+|-----------:|----:|-------------:|--------------:|-------------:|
+| 3 | 0 | 1 | — (skip) | 0 |
+| 2 | 1 | 1 | C(2, 1) = **2** | 2 |
+| 1 | 0 | 0 | — (done, onesLeft = 0) | 2 |
+| 0 | 0 | 0 | — (done) | 2 |
+
+Result: **o = 2**.
+
+Sanity check by enumerating all class-1 patterns of width 4 in increasing offset order:
+
+| offset | pattern |
+|------:|--------:|
+| 0 | `0001` |
+| 1 | `0010` |
+| 2 | `0100` |
+| 3 | `1000` |
+
+Offset 2 ↔ `0100`. ✓
+
+## Decode: (class = 1, offset = 2) → 0100
+
+`CombDecode` reverses the process. It scans positions MSB-to-LSB and greedily places a 1-bit at position `p` whenever `offset ≥ C(p, onesLeft)`, then subtracts the coefficient.
+
+| bitPos `p` | C(p, onesLeft) | offset ≥ coeff? | action | offset after |
+|-----------:|---------------:|:----------------|:-------|-------------:|
+| 3 | C(3, 1) = 3 | 2 ≥ 3? **no** | skip | 2 |
+| 2 | C(2, 1) = 2 | 2 ≥ 2? **yes** | set bit 2 | 0 |
+| 1 | — | onesLeft = 0 | done | 0 |
+| 0 | — | onesLeft = 0 | done | 0 |
+
+Result: bit 2 set, all others 0 → **`0100`**. ✓
+
+## Why C(p, r) Counts Smaller Patterns
+
+When the encoder sees a 1-bit at position `p` with `r` ones still to place (counting the current one), every pattern that has a 0 at position `p` and the same `r` ones spread across positions `0..p-1` comes before β in offset order. There are exactly `C(p, r)` such patterns — choose `r` positions for the remaining ones out of the `p` lower positions.
+
+The full lexicographic-ordering argument (treating bit positions as a `c`-subset of `{0, …, b−1}`) is laid out in [Why This Works](posts/combinatorial-encoding-for-compression.md#why-this-works).
+
+## Edge Cases
+
+`CombEncode` and `CombDecode` short-circuit when the class is extremal:
+
+- **class = 0** → only one possible pattern (all zeros). Offset is 0, decode returns `0`. See [internal/combinatorial.go](../internal/combinatorial.go) lines 32–34 and 60–62.
+- **class = b** → only one possible pattern (all ones). Offset is 0, decode returns `(1 << b) - 1`. See [internal/combinatorial.go](../internal/combinatorial.go) lines 32–34 and 63–65.
+
+`OffsetBits(class)` returns 0 for both, so no bits at all are written for these classes — the class itself (stored separately in 4 bits) is the entire encoding.
+
+## See Also
+
+- [combinatorial-encoding-for-compression.md](posts/combinatorial-encoding-for-compression.md) — full 15-bit canonical example (β = `0b010110000000000` → o = 351), space analysis, performance numbers.
+- [zero-order-compression.md](zero-order-compression.md) — how RRR uses combinatorial encoding to achieve `nH₀(B) + o(n)` space.
+- [internal/combinatorial.go](../internal/combinatorial.go) — Go implementation of `CombEncode`, `CombDecode`, `OffsetBits`.
+- [rrr.go](../rrr.go) — how `NewRRR` calls `CombEncode` at construction and `Rank`/`Select` call `CombDecode` at query time.

--- a/docs/combinatorial-walkthrough.md
+++ b/docs/combinatorial-walkthrough.md
@@ -1,6 +1,6 @@
 # Combinatorial Encoding: A Tiny Worked Example
 
-A minimal walkthrough of how `CombEncode` and `CombDecode` map a bit pattern to its index among all patterns with the same popcount, and back. This page uses a 4-bit example so the whole derivation fits on one screen. For the canonical 15-bit case as it appears in production code, see [combinatorial-encoding-for-compression.md](posts/combinatorial-encoding-for-compression.md).
+A minimal walkthrough of how `CombEncode` and `CombDecode` map a bit pattern to its index among all patterns with the same popcount, and back. This page uses a 4-bit example so the whole derivation fits on one screen. For the canonical 15-bit case as it appears in production code, see [internal/combinatorial.go](../internal/combinatorial.go).
 
 ## The Problem
 
@@ -49,7 +49,7 @@ Result: bit 2 set, all others 0 → **`0100`**. ✓
 
 When the encoder sees a 1-bit at position `p` with `r` ones still to place (counting the current one), every pattern that has a 0 at position `p` and the same `r` ones spread across positions `0..p-1` comes before β in offset order. There are exactly `C(p, r)` such patterns — choose `r` positions for the remaining ones out of the `p` lower positions.
 
-The full lexicographic-ordering argument (treating bit positions as a `c`-subset of `{0, …, b−1}`) is laid out in [Why This Works](posts/combinatorial-encoding-for-compression.md#why-this-works).
+The full argument treats the set bit positions as a `c`-subset of `{0, …, b−1}` and ranks those subsets lexicographically.
 
 ## Edge Cases
 
@@ -62,7 +62,6 @@ The full lexicographic-ordering argument (treating bit positions as a `c`-subset
 
 ## See Also
 
-- [combinatorial-encoding-for-compression.md](posts/combinatorial-encoding-for-compression.md) — full 15-bit canonical example (β = `0b010110000000000` → o = 351), space analysis, performance numbers.
-- [zero-order-compression.md](zero-order-compression.md) — how RRR uses combinatorial encoding to achieve `nH₀(B) + o(n)` space.
+- [README.md](../README.md#documentation) — how RRR uses combinatorial encoding to reach the `nH₀(B) + o(n)` space bound.
 - [internal/combinatorial.go](../internal/combinatorial.go) — Go implementation of `CombEncode`, `CombDecode`, `OffsetBits`.
 - [rrr.go](../rrr.go) — how `NewRRR` calls `CombEncode` at construction and `Rank`/`Select` call `CombDecode` at query time.

--- a/docs/combinatorial-walkthrough.md
+++ b/docs/combinatorial-walkthrough.md
@@ -10,7 +10,9 @@ This file walks the algorithm on β = `0100` (b = 4, class = 1). The answer is o
 
 ## Encode: 0100 → 2
 
-`CombEncode` scans bit positions from MSB (position 3) down to LSB (position 0). At each 1-bit it adds `C(p, onesLeft)` to the running offset and decrements `onesLeft`. That coefficient counts the patterns lexicographically smaller than β that have a 0 at this position.
+`CombEncode(block, class)` takes no width parameter — it always scans from bit 14 down to bit 0, since the coefficient `C(p, r)` depends only on the position and the ones remaining, never on `b`. The high bits of a 4-bit pattern are zero, so the trace below starts at position 3. (`CombDecode(class, offset, b)` *does* take `b`; only the decoder needs to know where to start.)
+
+At each 1-bit the encoder adds `C(p, onesLeft)` to the running offset and decrements `onesLeft`. That coefficient counts the patterns lexicographically smaller than β that have a 0 at this position.
 
 | bitPos `p` | bit | onesLeft `r` | C(p, r) added | offset after |
 |-----------:|----:|-------------:|--------------:|-------------:|
@@ -53,12 +55,14 @@ The full argument treats the set bit positions as a `c`-subset of `{0, …, b−
 
 ## Edge Cases
 
-`CombEncode` and `CombDecode` short-circuit when the class is extremal:
+An extremal class admits only one pattern, so its offset carries no information. The short-circuits for this are written against the **production block size of 15**, not against a general `b`:
 
-- **class = 0** → only one possible pattern (all zeros). Offset is 0, decode returns `0`. See [internal/combinatorial.go](../internal/combinatorial.go) lines 32–34 and 60–62.
-- **class = b** → only one possible pattern (all ones). Offset is 0, decode returns `(1 << b) - 1`. See [internal/combinatorial.go](../internal/combinatorial.go) lines 32–34 and 63–65.
+- **class = 0** → all zeros. `CombEncode` returns 0; `CombDecode` returns `0`.
+- **class = 15** → all ones. `CombEncode` returns 0; `CombDecode` returns `(1 << b) - 1` via its `class == b` test.
 
-`OffsetBits(class)` returns 0 for both, so no bits at all are written for these classes — the class itself (stored separately in 4 bits) is the entire encoding.
+`OffsetBits(class)` likewise special-cases only 0 and 15, and otherwise sizes the offset from `C(15, class)`. So at b = 15 no offset bits are written for either extreme, and the class alone (packed separately in 4 bits) is the entire encoding.
+
+**This does not generalize to the 4-bit example above.** `CombEncode`'s guard tests `class == 15` literally, so `CombEncode(0b1111, 4)` does not short-circuit — it falls through the loop and returns 0 only because the coefficients it reads are unpopulated (zero) table entries. And `OffsetBits(4)` returns 11, sizing an offset for `C(15, 4)` rather than the single 4-bit pattern. The toy width is a teaching device for the ranking itself; the extremal-class handling is 15-specific.
 
 ## See Also
 

--- a/docs/combinatorial-walkthrough.md
+++ b/docs/combinatorial-walkthrough.md
@@ -1,68 +1,137 @@
 # Combinatorial Encoding: A Tiny Worked Example
 
-A minimal walkthrough of how `CombEncode` and `CombDecode` map a bit pattern to its index among all patterns with the same popcount, and back. This page uses a 4-bit example so the whole derivation fits on one screen. For the canonical 15-bit case as it appears in production code, see [internal/combinatorial.go](../internal/combinatorial.go).
+RRR replaces each `b`-bit block with a `(class, offset)` pair: the **class** is the block's popcount, the **offset** is its index among all blocks sharing that popcount. This page derives both directions by hand on a 4-bit block, then repeats the derivation at the production width of 15 and shows what it costs.
+
+Implementation: [internal/combinatorial.go](../internal/combinatorial.go).
 
 ## The Problem
 
-Given a `b`-bit block β with `c` 1-bits (its **class**), there are exactly `C(b, c)` possible patterns. Assigning each pattern a unique index in `[0, C(b, c) - 1]` (its **offset**) lets us replace the `b` raw bits with `(class, offset)` — and the offset takes only `⌈log₂ C(b, c)⌉` bits, which is smaller than `b` whenever the pattern is sparse or dense.
+Given a `b`-bit block β with `c` 1-bits, exactly `C(b, c)` patterns share that class. Number them `0 … C(b, c) - 1` and β can be stored as `(c, offset)` instead of `b` raw bits — the offset needs only `⌈log₂ C(b, c)⌉` bits, far fewer than `b` when the block is mostly 0s or mostly 1s.
 
-This file walks the algorithm on β = `0100` (b = 4, class = 1). The answer is o = 2.
+The numbering is the **combinatorial number system**, which yields an invariant worth holding onto:
 
-## Encode: 0100 → 2
+> Within a class, offset order *is* numeric order. The numerically smallest block of class `c` has offset 0; the largest has offset `C(b, c) - 1`.
 
-`CombEncode(block, class)` takes no width parameter — it always scans from bit 14 down to bit 0, since the coefficient `C(p, r)` depends only on the position and the ones remaining, never on `b`. The high bits of a 4-bit pattern are zero, so the trace below starts at position 3. (`CombDecode(class, offset, b)` *does* take `b`; only the decoder needs to know where to start.)
+Worked example: β = `0110`, b = 4, class = 2. The answer is offset 2.
 
-At each 1-bit the encoder adds `C(p, onesLeft)` to the running offset and decrements `onesLeft`. That coefficient counts the patterns lexicographically smaller than β that have a 0 at this position.
+## Encode: `0110` → 2
+
+`CombEncode(block, class)` takes no width parameter — it always scans from bit 14 down to bit 0, because the coefficient `C(p, r)` depends only on the position `p` and the ones remaining `r`, never on `b`. A 4-bit pattern is zero above bit 3, so the trace starts there. (`CombDecode(class, offset, b)` *does* take `b`; only the decoder needs to know where to begin.)
+
+At each 1-bit the encoder adds `C(p, onesLeft)` to the running offset, then decrements `onesLeft`. The loop stops as soon as `onesLeft` hits 0:
 
 | bitPos `p` | bit | onesLeft `r` | C(p, r) added | offset after |
 |-----------:|----:|-------------:|--------------:|-------------:|
-| 3 | 0 | 1 | — (skip) | 0 |
-| 2 | 1 | 1 | C(2, 1) = **2** | 2 |
-| 1 | 0 | 0 | — (done, onesLeft = 0) | 2 |
-| 0 | 0 | 0 | — (done) | 2 |
+| 3 | 0 | 2 | — (skip) | 0 |
+| 2 | 1 | 2 | C(2, 2) = **1** | 1 |
+| 1 | 1 | 1 | C(1, 1) = **1** | 2 |
+| 0 | — | 0 | — (loop ends) | 2 |
 
-Result: **o = 2**.
+Result: **offset = 2**.
 
-Sanity check by enumerating all class-1 patterns of width 4 in increasing offset order:
+Sanity check — all `C(4, 2) = 6` class-2 patterns, in offset order:
 
 | offset | pattern |
 |------:|--------:|
-| 0 | `0001` |
-| 1 | `0010` |
-| 2 | `0100` |
-| 3 | `1000` |
+| 0 | `0011` |
+| 1 | `0101` |
+| 2 | `0110` |
+| 3 | `1001` |
+| 4 | `1010` |
+| 5 | `1100` |
 
-Offset 2 ↔ `0100`. ✓
+`0110` sits at offset 2. ✓ Note the patterns ascend numerically (3, 5, 6, 9, 10, 12) — that is the invariant above.
 
-## Decode: (class = 1, offset = 2) → 0100
+## Decode: (class 2, offset 2) → `0110`
 
-`CombDecode` reverses the process. It scans positions MSB-to-LSB and greedily places a 1-bit at position `p` whenever `offset ≥ C(p, onesLeft)`, then subtracts the coefficient.
+`CombDecode` reverses the walk. It scans MSB-to-LSB and greedily places a 1-bit wherever `offset ≥ C(p, onesLeft)`, subtracting the coefficient it consumes:
 
 | bitPos `p` | C(p, onesLeft) | offset ≥ coeff? | action | offset after |
 |-----------:|---------------:|:----------------|:-------|-------------:|
-| 3 | C(3, 1) = 3 | 2 ≥ 3? **no** | skip | 2 |
-| 2 | C(2, 1) = 2 | 2 ≥ 2? **yes** | set bit 2 | 0 |
-| 1 | — | onesLeft = 0 | done | 0 |
-| 0 | — | onesLeft = 0 | done | 0 |
+| 3 | C(3, 2) = 3 | 2 ≥ 3? **no** | skip | 2 |
+| 2 | C(2, 2) = 1 | 2 ≥ 1? **yes** | set bit 2 | 1 |
+| 1 | C(1, 1) = 1 | 1 ≥ 1? **yes** | set bit 1 | 0 |
+| 0 | — | onesLeft = 0 | loop ends | 0 |
 
-Result: bit 2 set, all others 0 → **`0100`**. ✓
+Bits 2 and 1 set → **`0110`**. ✓
+
+Greedy works because the coefficients strictly decrease as `p` falls: taking the largest affordable coefficient at each step is forced, exactly as in positional notation.
 
 ## Why C(p, r) Counts Smaller Patterns
 
-When the encoder sees a 1-bit at position `p` with `r` ones still to place (counting the current one), every pattern that has a 0 at position `p` and the same `r` ones spread across positions `0..p-1` comes before β in offset order. There are exactly `C(p, r)` such patterns — choose `r` positions for the remaining ones out of the `p` lower positions.
+When the encoder meets a 1-bit at position `p` with `r` ones still to place (counting this one), consider every pattern that agrees with β above `p` but has a **0** at position `p`. Each must fit all `r` remaining ones into the `p` positions below, and every one of them is numerically smaller than β. There are exactly `C(p, r)` ways to choose those positions — so the coefficient is precisely the count of class-mates skipped over by setting this bit.
 
-The full argument treats the set bit positions as a `c`-subset of `{0, …, b−1}` and ranks those subsets lexicographically.
+Summing over the set bits ranks β among the `c`-subsets of `{0, …, b−1}`.
+
+## At Production Scale: b = 15
+
+The same derivation on a real block. β = `000000101000010`, class 3, with bits set at positions 8, 6 and 1:
+
+| bitPos `p` | onesLeft `r` | C(p, r) added | offset after |
+|-----------:|-------------:|--------------:|-------------:|
+| 8 | 3 | C(8, 3) = **56** | 56 |
+| 6 | 2 | C(6, 2) = **15** | 71 |
+| 1 | 1 | C(1, 1) = **1** | 72 |
+
+Offset 72, which `OffsetBits(3) = 9` bits hold comfortably. So 15 raw bits become a 4-bit class plus a 9-bit offset — **13 bits**.
+
+## What It Buys, and When It Doesn't
+
+`OffsetBits(c)` is `⌈log₂ C(15, c)⌉`. Adding the 4-bit class gives the true per-block cost:
+
+| class `c` | C(15, c) | offset bits | + 4-bit class | vs. 15 raw |
+|---------:|---------:|------------:|--------------:|-----------:|
+| 0 | 1 | 0 | 4 | −11 |
+| 1 | 15 | 4 | 8 | −7 |
+| 2 | 105 | 7 | 11 | −4 |
+| 3 | 455 | 9 | 13 | −2 |
+| 4 | 1365 | 11 | 15 | 0 |
+| 5 | 3003 | 12 | 16 | **+1** |
+| 6 | 5005 | 13 | 17 | **+2** |
+| 7 | 6435 | 13 | 17 | **+2** |
+| 8 | 6435 | 13 | 17 | **+2** |
+| 9 | 5005 | 13 | 17 | **+2** |
+| 10 | 3003 | 12 | 16 | **+1** |
+| 11 | 1365 | 11 | 15 | 0 |
+| 12 | 455 | 9 | 13 | −2 |
+| 13 | 105 | 7 | 11 | −4 |
+| 14 | 15 | 4 | 8 | −7 |
+| 15 | 1 | 0 | 4 | −11 |
+
+The table is symmetric, and mid-range classes **cost more than the raw bits they replace**. A balanced block (class 5–10) expands by 1–2 bits; only skewed blocks pay for themselves, and the extremes save 11.
+
+That is the `nH₀(B)` bound made concrete: the win comes from the *distribution* of classes, not from any single block. On uniformly random bits the classes cluster at 7 and 8 and RRR is a net loss. On sparse or dense data the mass sits at the ends of the table and it wins big — which is why the README recommends RRR only when density is far from 50%.
+
+## Where the Pair Lands in Memory
+
+[rrr.go](../rrr.go) stores the two halves separately, which is what makes the offsets reachable at all:
+
+- **Classes** — 4 bits per block (0–15 fits exactly), packed into a `[]uint64`. Fixed width, so block `i`'s class is a direct index.
+- **Offsets** — variable width, bit-packed back to back with no padding. This *cannot* be indexed directly: block `i`'s offset begins wherever the previous `i` offsets happened to end.
+- **Superblocks** — one `uint64` per 16 blocks, packing cumulative rank in the high 32 bits and the cumulative *offset-bit position* in the low 32.
+
+The superblock's low half is what rescues the offsets: `Rank` jumps to the nearest superblock, then walks at most 16 classes, summing `OffsetBits` until it arrives at the target block's offset. A bounded scan, hence O(1).
 
 ## Edge Cases
 
-An extremal class admits only one pattern, so its offset carries no information. The short-circuits for this are written against the **production block size of 15**, not against a general `b`:
+An extremal class admits only one pattern, so its offset carries no information. The short-circuits are written against the **production block size of 15**, not a general `b`:
 
 - **class = 0** → all zeros. `CombEncode` returns 0; `CombDecode` returns `0`.
 - **class = 15** → all ones. `CombEncode` returns 0; `CombDecode` returns `(1 << b) - 1` via its `class == b` test.
 
-`OffsetBits(class)` likewise special-cases only 0 and 15, and otherwise sizes the offset from `C(15, class)`. So at b = 15 no offset bits are written for either extreme, and the class alone (packed separately in 4 bits) is the entire encoding.
+`OffsetBits` special-cases only 0 and 15, sizing every other class from `C(15, class)`. At b = 15 that means no offset bits at all for either extreme — the 4-bit class is the entire encoding, the −11 rows in the table above.
 
-**This does not generalize to the 4-bit example above.** `CombEncode`'s guard tests `class == 15` literally, so `CombEncode(0b1111, 4)` does not short-circuit — it falls through the loop and returns 0 only because the coefficients it reads are unpopulated (zero) table entries. And `OffsetBits(4)` returns 11, sizing an offset for `C(15, 4)` rather than the single 4-bit pattern. The toy width is a teaching device for the ranking itself; the extremal-class handling is 15-specific.
+**This does not generalize to the 4-bit example.** `CombEncode`'s guard tests `class == 15` literally, so `CombEncode(0b1111, 4)` does not short-circuit — it falls through the loop and returns 0 only because the coefficients it reads are unpopulated (zero) table entries. And `OffsetBits(4)` returns 11, sizing an offset for `C(15, 4)` rather than for the single 4-bit pattern. The toy width teaches the ranking; the extremal-class handling is 15-specific.
+
+## Verify It Yourself
+
+The `0110` example and the offset widths above are both asserted in the test suite:
+
+```sh
+go test ./internal/ -run 'TestWorkedExamples|TestOffsetBits|TestCombEncodeDecode' -v
+```
+
+`TestCombEncodeDecode` round-trips all 32768 blocks at b = 15.
 
 ## See Also
 

--- a/internal/combinatorial_test.go
+++ b/internal/combinatorial_test.go
@@ -70,11 +70,22 @@ func TestOffsetBits(t *testing.T) {
 		class    int
 		expected int
 	}{
+		// Every class, so the cost table in
+		// docs/combinatorial-walkthrough.md stays honest.
 		{0, 0},   // C(15,0) = 1, need 0 bits
 		{1, 4},   // C(15,1) = 15, need 4 bits (ceil(log2(15)) = 4)
 		{2, 7},   // C(15,2) = 105, need 7 bits
+		{3, 9},   // C(15,3) = 455, need 9 bits
+		{4, 11},  // C(15,4) = 1365, need 11 bits
+		{5, 12},  // C(15,5) = 3003, need 12 bits
+		{6, 13},  // C(15,6) = 5005, need 13 bits
 		{7, 13},  // C(15,7) = 6435, need 13 bits
 		{8, 13},  // C(15,8) = 6435, need 13 bits
+		{9, 13},  // C(15,9) = 5005, need 13 bits
+		{10, 12}, // C(15,10) = 3003, need 12 bits
+		{11, 11}, // C(15,11) = 1365, need 11 bits
+		{12, 9},  // C(15,12) = 455, need 9 bits
+		{13, 7},  // C(15,13) = 105, need 7 bits
 		{14, 4},  // C(15,14) = 15, need 4 bits
 		{15, 0},  // C(15,15) = 1, need 0 bits
 	}
@@ -161,12 +172,16 @@ func TestWorkedExamples(t *testing.T) {
 		t.Errorf("CombDecode(1, 8, 15) = 0x%x; want 0x0100", decoded)
 	}
 
-	// Another example: 0x0006 = bits 1,2 set, class=2
-	// Patterns before: 0x0003 (bits 0,1)
-	// offset should be 1
+	// Another example: 0x0006 = bits 1,2 set, class=2. This is the worked
+	// example in docs/combinatorial-walkthrough.md.
+	// Two class-2 patterns are numerically smaller: 0x0003 (bits 0,1) and
+	// 0x0005 (bits 0,2). So offset is 2.
 	block2 := uint16(0x0006) // bits 1,2 set
 	class2 := bits.OnesCount16(block2)
 	offset2 := CombEncode(block2, class2)
+	if offset2 != 2 {
+		t.Errorf("CombEncode(0x0006, 2) = %d; want 2", offset2)
+	}
 	decoded2 := CombDecode(class2, offset2, 15)
 	if decoded2 != block2 {
 		t.Errorf("roundtrip failed for 0x%x: got 0x%x", block2, decoded2)


### PR DESCRIPTION
Restores the combinatorial encoding walkthrough as a page that explains what RRR actually costs, and pins its numbers to the test suite so they cannot drift.

## What's here

**The walkthrough** (`docs/combinatorial-walkthrough.md`, new) derives `CombEncode`/`CombDecode` by hand on a 4-bit block, repeats the derivation on a real 15-bit block, then covers the cost table, the memory layout, and the extremal-class edge cases.

The worked example is `0110` (class 2) rather than a class-1 block, since class 1 is the one case where the algorithm demonstrates nothing — a single coefficient, `onesLeft` decremented once. Class 2 shows both the accumulation and the decrement.

**The cost table** is the part worth reviewing. With the 4-bit class included, the per-block totals are:

| class | offset bits | + 4-bit class | vs. 15 raw |
|------:|------------:|--------------:|-----------:|
| 0 / 15 | 0 | 4 | −11 |
| 1 / 14 | 4 | 8 | −7 |
| 3 / 12 | 9 | 13 | −2 |
| 4 / 11 | 11 | 15 | 0 |
| 5 / 10 | 12 | 16 | **+1** |
| 6–9 | 13 | 17 | **+2** |

Classes 5–10 take 16–17 bits to store 15 raw ones. RRR is a net loss on balanced data and only pays off on skewed distributions — which is what the `nH₀(B)` bound is saying, and seems better stated plainly in the docs than discovered in a benchmark.

Also documents why variable-width offsets are addressable at all (the superblock's low 32 bits hold a cumulative offset-bit position, so `Rank` walks at most 16 classes), and the offset-order-is-numeric-order invariant.

## Two bugs found while verifying

- **`README.md` claimed offsets shrink "from 15 bits at class 7/8".** It is 13. The 9-bit and 4-bit figures were correct.
- **`TestWorkedExamples` had the wrong answer in a comment** — it said `0x0006` encodes to offset 1, missing `0x0005` as a smaller class-2 pattern. It is 2. Nothing caught this because the test asserted only the round trip; the assertion is now there.

## Keeping it honest

`TestOffsetBits` went from 7 classes to all 16, so the cost table is test-enforced rather than asserted once. Every figure in the page was verified against the real code, including full `CombEncode`/`CombDecode` round trips at b=4 and all 32768 blocks at b=15.

The page is linked from the README's Documentation section; previously nothing linked to it.

## Testing

`go vet ./...` and `go test ./...` pass. Docs-only apart from the test file — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
